### PR TITLE
Download dynamodb from cloudfront instead of old s3 uri

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install DynamoDB
       run: |
         mkdir /tmp/dynamodb
-        wget -O - https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz | tar xz --directory /tmp/dynamodb
+        wget -O - https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_latest.tar.gz | tar xz --directory /tmp/dynamodb
     - uses: fizyk/actions-reuse/.github/actions/pipenv@v3.0.2
       with:
         python-version: ${{ matrix.python-version }}

--- a/newsfragments/+d4293a47.misc.rst
+++ b/newsfragments/+d4293a47.misc.rst
@@ -1,0 +1,1 @@
+Download dynamodb from cloudfront instead of old s3 link


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.
