### PR TITLE
Ability for dynamodb client fixture to connect to external dynamodb -…

### DIFF
--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run docker tests
 
 on:
   push:
@@ -7,16 +7,21 @@ on:
     branches: [ main ]
 
 jobs:
-  tests:
+  docker-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       OS: ubuntu-latest
       PYTHON: ${{ matrix.python-version }}
     # Service containers to run with `container-job`
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local:2.6.0
+        ports:
+          - 8088:8000
 
     steps:
     - uses: actions/checkout@v4
@@ -24,18 +29,14 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install DynamoDB
-      run: |
-        mkdir /tmp/dynamodb
-        wget -O - https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_latest.tar.gz | tar xz --directory /tmp/dynamodb
     - uses: fizyk/actions-reuse/.github/actions/pipenv@v3.0.2
       with:
         python-version: ${{ matrix.python-version }}
-        command: pytest -n 0 -k "not docker" --cov-report=xml
+        command: pytest -n 0 --cov-report=xml -k docker --dynamodb-host=localhost --dynamodb-port=8088
     - uses: fizyk/actions-reuse/.github/actions/pipenv@v3.0.2
       with:
         python-version: ${{ matrix.python-version }}
-        command: pytest -n 1 -k "not docker" --cov-report=xml:coverage-xdist.xml
+        command: pytest -n 1 --cov-report=xml:coverage-xdist.xml -k docker --dynamodb-host=localhost --dynamodb-port=8088
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5.4.0
       with:

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Plugin contains two fixtures
 
 * **dynamodb** - it's a client/resource fixture that has functional scope. After each test it drops tables in DynamoDB.
 * **dynamodb_proc** - session scoped fixture, that starts DynamoDB instance at it's first use and stops at the end of the tests.
+* **dynamodb_noproc** - session scoped fixture, that's used to connect to dynamodb mained externally (like docker).
 
 Simply include one of these fixtures into your tests fixture list.
 
@@ -63,6 +64,19 @@ You can also create additional dynamodb client and process fixtures if you'd nee
     dynamodb_my_proc = factories.dynamodb_proc(
         port=None, logsdir='/tmp', delay=True)
     dynamodb_my = factories.dynamodb('dynamodb_my_proc')
+
+.. note::
+
+    Each DynamoDB process fixture can be configured in a different way than the others through the fixture factory arguments.
+
+
+.. code-block:: python
+
+    from pytest_dynamodb import factories
+
+    dynamodb_my_noproc = factories.dynamodb_noproc(
+        host="dynamodb", port=8088)
+    dynamodb_my = factories.dynamodb('dynamodb_my_noproc')
 
 .. note::
 

--- a/newsfragments/813.feature.rst
+++ b/newsfragments/813.feature.rst
@@ -1,0 +1,1 @@
+Client fixtures now have the ability to connect to existing DynamoDB instance maintained externally (like docker)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,9 @@ target-version = ['py39']
 include = '.*\.pyi?$'
 
 [tool.ruff]
-# Decrease the maximum line length to 79 characters.
 line-length = 100
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle
     "F",   # pyflakes

--- a/pytest_dynamodb/config.py
+++ b/pytest_dynamodb/config.py
@@ -17,7 +17,7 @@
 """Configuration tools for pytest-dynamodb."""
 
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, Optional, TypedDict
 
 from _pytest.fixtures import FixtureRequest
 
@@ -27,8 +27,8 @@ class PytestDynamoDBConfigType(TypedDict):
 
     dir: Path
     host: str
-    port: str
-    delay: str
+    port: Optional[int]
+    delay: bool
     aws_access_key: str
     aws_secret_key: str
     aws_region: str
@@ -43,11 +43,15 @@ def get_config(request: FixtureRequest) -> PytestDynamoDBConfigType:
             option_name
         )
 
+    port = None
+    if get_conf_option("port"):
+        port = int(get_conf_option("port"))
+
     config: PytestDynamoDBConfigType = {
         "dir": get_conf_option("dir"),
         "host": get_conf_option("host"),
-        "port": get_conf_option("port"),
-        "delay": get_conf_option("delay"),
+        "port": port,
+        "delay": bool(get_conf_option("delay")),
         "aws_access_key": get_conf_option("aws_access_key"),
         "aws_secret_key": get_conf_option("aws_secret_key"),
         "aws_region": get_conf_option("aws_region"),

--- a/pytest_dynamodb/factories/__init__.py
+++ b/pytest_dynamodb/factories/__init__.py
@@ -17,6 +17,7 @@
 """Fixture factories."""
 
 from pytest_dynamodb.factories.client import dynamodb
+from pytest_dynamodb.factories.noprocess import dynamodb_noproc
 from pytest_dynamodb.factories.process import dynamodb_proc
 
-__all__ = ("dynamodb_proc", "dynamodb")
+__all__ = ("dynamodb_proc", "dynamodb", "dynamodb_noproc")

--- a/pytest_dynamodb/factories/client.py
+++ b/pytest_dynamodb/factories/client.py
@@ -15,14 +15,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with pytest-dynamodb. If not, see <http://www.gnu.org/licenses/>.
 """Client fixture factory."""
-from typing import Any, Callable, Generator, Optional
+from typing import Any, Callable, Generator, Optional, Union
 
 import boto3
 import pytest
+from mirakuru import TCPExecutor
 from mypy_boto3_dynamodb import DynamoDBServiceResource
 from pytest import FixtureRequest
 
 from pytest_dynamodb.config import get_config
+from pytest_dynamodb.factories.noprocess import NoProcExecutor
 
 
 def dynamodb(
@@ -52,7 +54,9 @@ def dynamodb(
             https://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Client
         :returns: connection to DynamoDB database
         """
-        proc_fixture = request.getfixturevalue(process_fixture_name)
+        proc_fixture: Union[TCPExecutor, NoProcExecutor] = (
+            request.getfixturevalue(process_fixture_name)
+        )
         config = get_config(request)
 
         dynamo_db = boto3.resource(
@@ -68,6 +72,3 @@ def dynamodb(
             table.delete()
 
     return dynamodb_factory
-
-
-__all__ = ("dynamodb",)

--- a/pytest_dynamodb/factories/noprocess.py
+++ b/pytest_dynamodb/factories/noprocess.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2025 by Authors.
+
+# This file is part of pytest-dynamodb.
+
+# pytest-dynamodb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# pytest-dynamodb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with pytest-dynamodb. If not, see <http://www.gnu.org/licenses/>.
+"""No process fixture factory."""
+from typing import Any, Callable, Generator, NamedTuple, Optional
+
+import pytest
+from pytest import FixtureRequest
+
+from pytest_dynamodb.config import get_config
+
+
+class NoProcExecutor(NamedTuple):
+    """Fake executor."""
+
+    host: str
+    port: int
+
+
+def dynamodb_noproc(
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+) -> Callable[[FixtureRequest], Any]:
+    """Process fixture factory for DynamoDB.
+
+    :param str host: hostname
+    :param int port: port
+
+    .. note::
+
+        For more information visit:
+            http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
+
+    :return: function which makes a DynamoDB process
+    """
+
+    @pytest.fixture(scope="session")
+    def dynamodb_noproc_fixture(
+        request: FixtureRequest,
+    ) -> Generator[NoProcExecutor, None, None]:
+        """Process fixture for DynamoDB.
+
+        It starts DynamoDB when first used and stops it at the end
+        of the tests. Works on ``DynamoDBLocal.jar``.
+
+        :param FixtureRequest request: fixture request object
+        :rtype: pytest_dbfixtures.executors.TCPExecutor
+        :returns: tcp executor
+        """
+        config = get_config(request)
+
+        dynamodb_port = port or config["port"] or 8000
+        dynamodb_host = host or config["host"]
+
+        noop_exec = NoProcExecutor(dynamodb_host, dynamodb_port)
+
+        yield noop_exec
+
+    return dynamodb_noproc_fixture

--- a/pytest_dynamodb/plugin.py
+++ b/pytest_dynamodb/plugin.py
@@ -112,4 +112,5 @@ def pytest_addoption(parser: Parser) -> None:
 
 
 dynamodb_proc = pytest_dynamodb.factories.process.dynamodb_proc()
+dynamodb_noproc = pytest_dynamodb.factories.noprocess.dynamodb_noproc()
 dynamodb = factories.dynamodb("dynamodb_proc")

--- a/tests/docker/test_noproc_docker.py
+++ b/tests/docker/test_noproc_docker.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2025 by Authors.
+
+# This file is part of pytest-dynamodb.
+
+# pytest-dynamodb is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# pytest-dynamodb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with pytest-dynamodb. If not, see <http://www.gnu.org/licenses/>.
+"""Test module for pytest-dynamodb."""
+
+import uuid
+
+from mypy_boto3_dynamodb import DynamoDBServiceResource
+
+from pytest_dynamodb import factories
+
+dynamodb = factories.dynamodb("dynamodb_noproc")
+
+
+def test_dynamodb(dynamodb: DynamoDBServiceResource) -> None:
+    """Simple test for DynamoDB.
+
+    # Create a table
+    # Put an item
+    # Get the item and check the content of this item
+    """
+    # create a table
+    table = dynamodb.create_table(
+        TableName="Test",
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        ProvisionedThroughput={
+            "ReadCapacityUnits": 10,
+            "WriteCapacityUnits": 10,
+        },
+    )
+
+    _id = str(uuid.uuid4())
+
+    # put an item into db
+    table.put_item(
+        Item={"id": _id, "test_key": "test_value"},
+    )
+
+    # get the item
+    item = table.get_item(
+        Key={
+            "id": _id,
+        }
+    )
+
+    # check the content of the item
+    assert item["Item"]["test_key"] == "test_value"
+
+
+def test_if_tables_does_not_exist(dynamodb: DynamoDBServiceResource) -> None:
+    """We should clear this fixture (remove all tables).
+
+    .. note::
+        `all` method on tables object creates an iterable of all
+        Table resources in the collection.
+    """
+    assert not list(dynamodb.tables.all())


### PR DESCRIPTION
… closes #813

Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.
