### PR TITLE
Add pyproject-fmt to pre-commit - close #1743

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,8 @@
 language: en-GB
 reviews:
+  profile: "assertive"
+  suggested_labels: true
+  auto_apply_labels: true
   path_instructions:
     - path: "newsfragments/*.rst"
       instructions: |
@@ -22,6 +25,13 @@ reviews:
           Check if a newsfragment file has been added to the newsfragments/ directory.
           Read the towncrier configuration from pyproject.toml to determine valid newsfragment types.
           If no newsfragment is present, suggest which type should be added based on the PR changes.
-          Suggest the filename format: [issue_or_pr_number].[type].rst (or +[hash].[type].rst for orphan fragments)
-          Remind contributors to use: `pipenv run towncrier create [number].[type].rst` (or `pipenv run towncrier create +.[type]` for orphan fragments)
+          Suggest the filename format: [issue_number].[type].rst (or +[hash].[type].rst for orphan fragments)
+          Remind contributors to use: `uv run towncrier create [issue_number].[type].rst` (or `uv run towncrier create +.[type].rst` for orphan fragments)
           Skip the check if the PR only updates existing newsfragments or is a trivial change.
+  auto_review:
+    auto_pause_after_reviewed_commits: 1
+    labels: ["!no code rabbit"]
+    drafts: false
+  slop_detection:
+    enabled: true
+    label: "ai-spam"

--- a/.github/ISSUE_TEMPLATE.rst
+++ b/.github/ISSUE_TEMPLATE.rst
@@ -1,7 +1,0 @@
-### What action do you want to perform
-
-
-### What are the results
-
-
-### What are the expected results

--- a/.github/PULL_REQUEST_TEMPLATE.rst
+++ b/.github/PULL_REQUEST_TEMPLATE.rst
@@ -1,5 +1,0 @@
-Chore that needs to be done:
-
-* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`
-
-Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,11 @@ repos:
       - id: rstcheck
         additional_dependencies: [sphinx, toml]
 
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.28.1
+    hooks:
+      - id: pyproject-fmt
+
   - repo: https://github.com/fizyk/pyproject-validator
     rev: v0.1.0
     hooks:

--- a/newsfragments/1743.misc.rst
+++ b/newsfragments/1743.misc.rst
@@ -1,0 +1,1 @@
+Add pyproject-fmt to pre-commit tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,87 +1,133 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools>=61.0.0" ]
+
 [project]
 name = "pytest-dynamodb"
 version = "3.0.0"
 description = "DynamoDB fixtures for pytest"
 readme = "README.rst"
-keywords = ["tests", "pytest", "fixture", "dynamodb", "aws", "boto"]
-license = {file = "COPYING.lesser"}
-authors = [
-    {name = "Grzegorz Śliwiński", email = "fizyk+pypi@fizyk.dev"}
-]
+keywords = [ "aws", "boto", "dynamodb", "fixture", "pytest", "tests" ]
+license = "LGPL-3.0-or-later"
+license-files = [ "COPYING.lesser" ]
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
+    "Framework :: Pytest",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Testing",
-    "Framework :: Pytest",
 ]
 dependencies = [
-    "pytest>=8.4.0",
-    "port-for>=0.7.3",
-    "mirakuru>=2.6.0",
     "boto3>=1.42.0",
     "boto3-stubs[dynamodb]",
+    "mirakuru>=2.6.0",
+    "port-for>=0.7.3",
+    "pytest>=8.4.0",
 ]
-requires-python = ">= 3.10"
+
+[[project.authors]]
+name = "Grzegorz Śliwiński"
+email = "fizyk+pypi@fizyk.dev"
 
 [project.urls]
-"Source" = "https://github.com/dbfixtures/pytest-dynamodb"
+Source = "https://github.com/dbfixtures/pytest-dynamodb"
 "Bug Tracker" = "https://github.com/dbfixtures/pytest-dynamodb/issues"
-"Changelog" = "https://github.com/dbfixtures/pytest-dynamodb/blob/v3.0.0/CHANGES.rst"
+Changelog = "https://github.com/dbfixtures/pytest-dynamodb/blob/v3.0.0/CHANGES.rst"
 
-[project.entry-points."pytest11"]
+[project.entry-points.pytest11]
 pytest_dynamodb = "pytest_dynamodb.plugin"
-
-[build-system]
-requires = ["setuptools >= 61.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 zip-safe = true
 
 [tool.setuptools.packages.find]
-include = ["pytest_dynamodb*"]
-exclude = ["tests*"]
+include = [ "pytest_dynamodb*" ]
+exclude = [ "tests*" ]
 namespaces = false
 
-[tool.pytest]
-xfail_strict = true
-testpaths = ["tests"]
-norecursedirs = ["tests/examples"]
-pytester_example_dir = "tests/examples"
-
 [tool.ruff]
+target-version = "py310"
 line-length = 100
-target-version = 'py310'
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle
-    "F",   # pyflakes
-    "I",   # isort
-    "D",   # pydocstyle
-    #Tryceratops
+    "E",      # pycodestyle
+    "F",      # pyflakes
+    "I",      # isort
+    "D",      # pydocstyle
+    # Tryceratops
     "TRY003",
 ]
 
+[tool.pyproject-fmt]
+column_width = 120
+indent = 4
+keep_full_version = true
+generate_python_version_classifiers = false
+table_format = "long"
+sub_table_spacing = "\n"
+
+[tool.pytest]
+norecursedirs = [ "tests/examples" ]
+pytester_example_dir = "tests/examples"
+testpaths = [ "tests" ]
+xfail_strict = true
+
+[tool.tbump]
+
+[[tool.tbump.before_commit]]
+name = "Build changelog"
+cmd = "pipenv run towncrier build --version {new_version} --yes"
+
+[[tool.tbump.field]]
+name = "extra"
+default = ""
+
+[[tool.tbump.file]]
+src = "pytest_dynamodb/__init__.py"
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'version = "{current_version}"'
+
+[[tool.tbump.file]]
+src = "pyproject.toml"
+search = 'Changelog = "https://github.com/dbfixtures/pytest-dynamodb/blob/v{current_version}/CHANGES.rst"'
+
+[tool.tbump.git]
+message_template = "Release {new_version}"
+tag_template = "v{new_version}"
+
+[tool.tbump.version]
+current = "3.0.0"
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (\-
+    (?P<extra>.+)
+  )?
+  '''
+
 [tool.towncrier]
 directory = "newsfragments"
-single_file=true
-filename="CHANGES.rst"
-issue_format="`#{issue} <https://github.com/dbfixtures/pytest-dynamodb/issues/{issue}>`_"
-
+filename = "CHANGES.rst"
+issue_format = "`#{issue} <https://github.com/dbfixtures/pytest-dynamodb/issues/{issue}>`_"
+single_file = true
 
 [[tool.towncrier.type]]
 directory = "break"
@@ -112,63 +158,3 @@ showcontent = true
 directory = "misc"
 name = "Miscellaneus"
 showcontent = true
-
-[tool.tbump]
-# Uncomment this if your project is hosted on GitHub:
-# github_url = "https://github.com/dbfixtures/pytest-dynamodb/"
-
-[tool.tbump.version]
-current = "3.0.0"
-
-# Example of a semver regexp.
-# Make sure this matches current_version before
-# using tbump
-regex = '''
-  (?P<major>\d+)
-  \.
-  (?P<minor>\d+)
-  \.
-  (?P<patch>\d+)
-  (\-
-    (?P<extra>.+)
-  )?
-  '''
-
-[tool.tbump.git]
-message_template = "Release {new_version}"
-tag_template = "v{new_version}"
-
-[[tool.tbump.field]]
-# the name of the field
-name = "extra"
-# the default value to use, if there is no match
-default = ""
-
-
-# For each file to patch, add a [[file]] config
-# section containing the path of the file, relative to the
-# tbump.toml location.
-[[tool.tbump.file]]
-src = "pytest_dynamodb/__init__.py"
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-search = 'version = "{current_version}"'
-
-[[tool.tbump.file]]
-src = "pyproject.toml"
-search = '"Changelog" = "https://github.com/dbfixtures/pytest-dynamodb/blob/v{current_version}/CHANGES.rst"'
-
-# You can specify a list of commands to
-# run after the files have been patched
-# and before the git commit is made
-
-[[tool.tbump.before_commit]]
-name = "Build changelog"
-cmd = "pipenv run towncrier build --version {new_version} --yes"
-
-# Or run some commands after the git tag and the branch
-# have been pushed:
-#  [[tool.tbump.after_push]]
-#  name = "publish"
-#  cmd = "./publish.sh"


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated project-formatting checks to improve consistency.
  * Updated project metadata and configuration for clearer packaging and maintenance.

* **Documentation**
  * Simplified issue and pull request templates by removing outdated prompts and checklist guidance.
  * Improved automated changelog and review workflow settings.

* **Release Notes**
  * Added a changelog entry documenting the new formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->