### PR TITLE
Add zizmor to pre-commit and fix findings - closes #1742

### DIFF
--- a/.github/workflows/single-tests-oldest.yml
+++ b/.github/workflows/single-tests-oldest.yml
@@ -37,7 +37,9 @@ jobs:
           - 8088:8000
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Install DynamoDB
       run: |
         mkdir /tmp/dynamodb
@@ -67,7 +69,7 @@ jobs:
         data-file: .coverage.docker
         output-file: coverage-docker.xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6.0.0
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
         files: coverage-serial.xml,coverage-xdist.xml,coverage-docker.xml
         flags: linux

--- a/.github/workflows/single-tests.yml
+++ b/.github/workflows/single-tests.yml
@@ -36,7 +36,9 @@ jobs:
           - 8088:8000
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Install DynamoDB
       run: |
         mkdir /tmp/dynamodb
@@ -62,7 +64,7 @@ jobs:
         data-file: .coverage.docker
         output-file: coverage-docker.xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6.0.0
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
         files: coverage-serial.xml,coverage-xdist.xml,coverage-docker.xml
         flags: linux

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   tests:
     uses: ./.github/workflows/single-tests.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,17 @@ repos:
       - id: rstcheck
         additional_dependencies: [sphinx, toml]
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+      - id: zizmor
+        args: [--no-progress, --fix]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.28.1
     hooks:

--- a/newsfragments/1742.misc.rst
+++ b/newsfragments/1742.misc.rst
@@ -1,0 +1,1 @@
+Add zizmor to pre-commit and set explicit minimal ``permissions`` on all workflow jobs

--- a/newsfragments/1758.misc.rst
+++ b/newsfragments/1758.misc.rst
@@ -1,0 +1,1 @@
+Add actionlint to pre-commit


### PR DESCRIPTION
    * Add actionlint to pre-commit - closes #1758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened workflow security by restricting default permissions and disabling unnecessary credential persistence.
  * Locked workflow actions to specific, verified revisions for more reliable execution.

* **Chores**
  * Added automated checks for GitHub Actions workflow security and syntax through pre-commit validation.

* **Documentation**
  * Added changelog entries covering the workflow security improvements and new validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->