### PR TITLE
Add Python 3.15 to CI - closes #1745

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,12 @@ jobs:
   tests:
     uses: ./.github/workflows/single-tests.yml
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy-3.11"]'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
   tests_oldest:
     uses: ./.github/workflows/single-tests-oldest.yml
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy-3.11"]'
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/newsfragments/1745.misc.rst
+++ b/newsfragments/1745.misc.rst
@@ -1,0 +1,1 @@
+Add Python 3.15 to CI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Python 3.15 to the standard and oldest-supported test workflows.

* **Documentation**
  * Added a changelog entry documenting Python 3.15 CI coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->