### PR TITLE
Enable PT ruff rulesets - closes #1753

### DIFF
--- a/newsfragments/1751.misc.rst
+++ b/newsfragments/1751.misc.rst
@@ -1,0 +1,1 @@
+Enable Ruff's TRY (tryceratops) rules

--- a/newsfragments/1753.misc.rst
+++ b/newsfragments/1753.misc.rst
@@ -1,0 +1,1 @@
+Enable Ruff's flake8-pytest-style rules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,12 +76,12 @@ line-length = 100
 
 [tool.ruff.lint]
 select = [
-    "E",      # pycodestyle
-    "F",      # pyflakes
-    "I",      # isort
-    "D",      # pydocstyle
-    # Tryceratops
-    "TRY003",
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "I",   # isort
+    "D",   # pydocstyle
+    "PT",  # flake8-pytest-style
+    "TRY", # tryceratops
 ]
 
 [tool.pyproject-fmt]

--- a/pytest_dynamodb/factories/client.py
+++ b/pytest_dynamodb/factories/client.py
@@ -22,7 +22,6 @@ import boto3
 import pytest
 from mirakuru import TCPExecutor
 from mypy_boto3_dynamodb import DynamoDBServiceResource
-from pytest import FixtureRequest
 
 from pytest_dynamodb.config import get_config
 from pytest_dynamodb.factories.noprocess import NoProcExecutor
@@ -41,7 +40,7 @@ def dynamodb(
     access_key: str | None = None,
     secret_key: str | None = None,
     region: str | None = None,
-) -> Callable[[FixtureRequest], Any]:
+) -> Callable[[pytest.FixtureRequest], Any]:
     """Fixture factory for DynamoDB resource.
 
     :param str process_fixture_name: name of the process fixture
@@ -54,7 +53,7 @@ def dynamodb(
 
     @pytest.fixture
     def dynamodb_factory(
-        request: FixtureRequest,
+        request: pytest.FixtureRequest,
     ) -> Generator[DynamoDBServiceResource, None, None]:
         """Fixture for DynamoDB resource.
 

--- a/pytest_dynamodb/factories/noprocess.py
+++ b/pytest_dynamodb/factories/noprocess.py
@@ -16,10 +16,9 @@
 # along with pytest-dynamodb. If not, see <http://www.gnu.org/licenses/>.
 """No process fixture factory."""
 
-from typing import Any, Callable, Generator, NamedTuple
+from typing import Callable, NamedTuple
 
 import pytest
-from pytest import FixtureRequest
 
 from pytest_dynamodb.config import get_config
 
@@ -34,7 +33,7 @@ class NoProcExecutor(NamedTuple):
 def dynamodb_noproc(
     host: str | None = None,
     port: int | None = None,
-) -> Callable[[FixtureRequest], Any]:
+) -> Callable[[pytest.FixtureRequest], NoProcExecutor]:
     """Process fixture factory for DynamoDB.
 
     :param str host: hostname
@@ -50,8 +49,8 @@ def dynamodb_noproc(
 
     @pytest.fixture(scope="session")
     def dynamodb_noproc_fixture(
-        request: FixtureRequest,
-    ) -> Generator[NoProcExecutor, None, None]:
+        request: pytest.FixtureRequest,
+    ) -> NoProcExecutor:
         """Process fixture for DynamoDB.
 
         It starts DynamoDB when first used and stops it at the end
@@ -68,6 +67,6 @@ def dynamodb_noproc(
 
         noop_exec = NoProcExecutor(dynamodb_host, dynamodb_port)
 
-        yield noop_exec
+        return noop_exec
 
     return dynamodb_noproc_fixture

--- a/pytest_dynamodb/factories/process.py
+++ b/pytest_dynamodb/factories/process.py
@@ -22,7 +22,6 @@ from typing import Callable, Generator, Iterable
 import pytest
 from mirakuru import ProcessExitedWithError, TCPExecutor
 from port_for import PortForException, PortType, get_port
-from pytest import FixtureRequest, TempPathFactory
 
 from pytest_dynamodb.config import DynamoDBConfig, get_config
 
@@ -76,7 +75,7 @@ def dynamodb_proc(
     host: str | None = None,
     port: PortType | None = None,
     delay: bool = False,
-) -> Callable[[FixtureRequest, TempPathFactory], Generator[TCPExecutor, None, None]]:
+) -> Callable[[pytest.FixtureRequest, pytest.TempPathFactory], Generator[TCPExecutor, None, None]]:
     """Process fixture factory for DynamoDB.
 
     :param str dynamodb_dir: a path to dynamodb dir (without spaces)
@@ -94,8 +93,8 @@ def dynamodb_proc(
 
     @pytest.fixture(scope="session")
     def dynamodb_proc_fixture(
-        request: FixtureRequest,
-        tmp_path_factory: TempPathFactory,
+        request: pytest.FixtureRequest,
+        tmp_path_factory: pytest.TempPathFactory,
     ) -> Generator[TCPExecutor, None, None]:
         """Process fixture for DynamoDB.
 

--- a/pytest_dynamodb/plugin.py
+++ b/pytest_dynamodb/plugin.py
@@ -17,7 +17,7 @@
 # along with pytest-dynamodb.  If not, see <http://www.gnu.org/licenses/>.
 """Plugin module of pytest-dynamodb."""
 
-from pytest import Parser
+import pytest
 
 import pytest_dynamodb.factories.process
 from pytest_dynamodb import factories
@@ -33,7 +33,7 @@ _help_aws_access_key = "AWS access key."
 _help_aws_region = "AWS region name."
 
 
-def pytest_addoption(parser: Parser) -> None:
+def pytest_addoption(parser: pytest.Parser) -> None:
     """Configure options for pytest-dynamodb."""
     parser.addini(name="dynamodb_dir", help=_help_dir, default="/tmp/dynamodb")
 

--- a/tests/test_dynamodb_pytester.py
+++ b/tests/test_dynamodb_pytester.py
@@ -21,7 +21,6 @@ import uuid
 import pytest
 from mirakuru import TCPExecutor
 from mypy_boto3_dynamodb import DynamoDBServiceResource
-from pytest import MonkeyPatch, Pytester
 
 pytest_plugins = ("pytester",)
 
@@ -29,8 +28,8 @@ pytest_plugins = ("pytester",)
 def test_teardown_preserves_preexisting_tables_in_child_pytest_run(
     dynamodb: DynamoDBServiceResource,
     dynamodb_proc: TCPExecutor,
-    pytester: Pytester,
-    monkeypatch: MonkeyPatch,
+    pytester: pytest.Pytester,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Child pytest run should clean only its own tables."""
     suffix = uuid.uuid4().hex


### PR DESCRIPTION
* Enable TRY ruff rulesets - closes #1751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Ruff’s TRY (Tryceratops) rule family.
  * Enabled Ruff’s flake8-pytest-style rules for improved test code quality.

* **Improvements**
  * Simplified the no-process DynamoDB fixture while preserving its behaviour.
  * Improved type annotations across DynamoDB fixtures, plugin hooks and testing utilities for clearer development support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->