### PR TITLE
Download local dynamodb from docker image in docker compose

### DIFF
--- a/.github/actions/dynamodb-local/action.yml
+++ b/.github/actions/dynamodb-local/action.yml
@@ -1,0 +1,34 @@
+name: DynamoDB Local
+description: >-
+  Start the DynamoDB Local service defined in docker-compose.yml and install its
+  DynamoDBLocal.jar, extracted from the very same image, for the process fixtures.
+
+inputs:
+  service:
+    description: 'Compose service running DynamoDB Local'
+    default: 'dynamodb'
+    required: false
+  dir:
+    description: 'Directory to install DynamoDBLocal.jar into'
+    default: '/tmp/dynamodb'
+    required: false
+
+runs:
+  using: composite
+  steps:
+  - name: Start DynamoDB Local
+    shell: bash
+    env:
+      SERVICE: ${{ inputs.service }}
+    run: docker compose up --detach --wait "$SERVICE"
+  - name: Install DynamoDB Local
+    shell: bash
+    env:
+      SERVICE: ${{ inputs.service }}
+      DIR: ${{ inputs.dir }}
+    run: |
+      mkdir --parents "$DIR"
+      cid=$(docker create "$(docker compose config --images "$SERVICE")")
+      # ``|| true`` keeps a failed cleanup from masking the exit status of the copy.
+      trap 'docker rm --force "$cid" > /dev/null || true' EXIT
+      docker cp "$cid:/home/dynamodblocal/." "$DIR/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,8 @@ updates:
     prefix: " "
 - package-ecosystem: github-actions
   directories:
-  - "/"
+    - "/"
+    - "/.github/actions/*"
   schedule:
     interval: daily
     time: "04:00"
@@ -34,6 +35,21 @@ updates:
     checkout:
       patterns:
       - "actions/checkout"
+    codecov:
+      patterns:
+      - "codecov/codecov-action"
+  commit-message:
+    prefix: " "
+- package-ecosystem: docker-compose
+  directories:
+  - "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: "04:20"
+  open-pull-requests-limit: 1
+  cooldown:
+    default-days: 7
   commit-message:
     prefix: " "
 - package-ecosystem: pre-commit

--- a/.github/workflows/single-tests-oldest.yml
+++ b/.github/workflows/single-tests-oldest.yml
@@ -29,21 +29,12 @@ jobs:
       OS: ${{ inputs.os }}
       PYTHON: ${{ matrix.python-version }}
       UV_NO_SYNC: "1"
-    # Service containers to run with `container-job`
-    services:
-      dynamodb:
-        image: amazon/dynamodb-local:3.3.0
-        ports:
-          - 8088:8000
-
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - name: Install DynamoDB
-      run: |
-        mkdir /tmp/dynamodb
-        wget -O - https://d1ni2b6xgvw0s0.cloudfront.net/v3.x/dynamodb_local_latest.tar.gz | tar xz --directory /tmp/dynamodb
+    - name: Set up DynamoDB Local
+      uses: ./.github/actions/dynamodb-local
     - name: Set up uv with python ${{ matrix.python-version }}
       uses: fizyk/actions-reuse/.github/actions/uv-setup@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
       with:

--- a/.github/workflows/single-tests.yml
+++ b/.github/workflows/single-tests.yml
@@ -28,21 +28,12 @@ jobs:
     env:
       OS: ${{ inputs.os }}
       PYTHON: ${{ matrix.python-version }}
-    # Service containers to run with `container-job`
-    services:
-      dynamodb:
-        image: amazon/dynamodb-local:3.3.0
-        ports:
-          - 8088:8000
-
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
-    - name: Install DynamoDB
-      run: |
-        mkdir /tmp/dynamodb
-        wget -O - https://d1ni2b6xgvw0s0.cloudfront.net/v3.x/dynamodb_local_latest.tar.gz | tar xz --directory /tmp/dynamodb
+    - name: Set up DynamoDB Local
+      uses: ./.github/actions/dynamodb-local
     - name: Set up uv with python ${{ matrix.python-version }}
       uses: fizyk/actions-reuse/.github/actions/uv-setup@7eefbd6ffc6c6787ad3be6ce93dcf475e3ae99b5 # v5.6.0
       with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+# DynamoDB Local for the tests selected with ``-k docker``.
+#
+# CI extracts ``DynamoDBLocal.jar`` from this same image, so the version used by
+# the client-side and the process fixtures is pinned in one place, and Dependabot
+# keeps it up to date.
+services:
+  dynamodb:
+    image: amazon/dynamodb-local:3.3.1
+    ports:
+      - "8088:8000"
+    healthcheck:
+      # DynamoDB Local answers a bare GET with 400 - any reply means it is up.
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8000/"]
+      interval: 2s
+      timeout: 5s
+      retries: 15

--- a/newsfragments/+dynamodb-local-docker.misc.rst
+++ b/newsfragments/+dynamodb-local-docker.misc.rst
@@ -1,0 +1,2 @@
+Pin DynamoDB Local to a single Docker image version in ``docker-compose.yml``,
+used both for the service container and to install ``DynamoDBLocal.jar`` in CI.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a reusable setup for DynamoDB Local in automated test environments.
  - Standardised the DynamoDB Local version used across test services and local test setup.
  - Added readiness checks to improve reliability when running tests that depend on DynamoDB.
  - Updated automated dependency monitoring to include repository actions and Docker Compose configuration.
  - Added release documentation covering the pinned DynamoDB Local image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->